### PR TITLE
Fully optional plotting

### DIFF
--- a/Python_version/config.py
+++ b/Python_version/config.py
@@ -12,6 +12,7 @@ is implemented.
 @author: Alexis Bottero (alexis.bottero@gmail.com)
 """
 
+import argparse
 try:
     # Python 3
     from configparser import SafeConfigParser
@@ -105,6 +106,13 @@ class Parameter(object):
         self.decayRate = cp.getfloat('global', 'DECAY_RATE')
         self.plot = cp.getboolean('global', 'PLOT')
         self.dplot = cp.getfloat('global', 'DPLOT')
+
+        parser = argparse.ArgumentParser(
+            description='Spectral element method in a 1D medium')
+        parser.add_argument('--no-plot', action='store_true',
+                            help='Force disable plotting')
+        args = parser.parse_args()
+        self.plot = self.plot and not args.no_plot
 
         self.nGLL = self.N + 1              # Number of GLL points per elements
         self.nGLJ = self.NGLJ + 1           # Number of GLJ in the first element

--- a/Python_version/config.py
+++ b/Python_version/config.py
@@ -20,7 +20,6 @@ except ImportError:
     from ConfigParser import SafeConfigParser
 
 import numpy as np
-import matplotlib.pyplot as plt
 
 import gll
 import functions
@@ -166,6 +165,7 @@ class Source(object):
 
     def plotSource(self,fig=1):
         """Plot the source"""
+        import matplotlib.pyplot as plt
         t = np.linspace(0, self.hdur, 1000)
         plt.figure(fig)
         plt.plot(t,self[t],'b')

--- a/Python_version/grid.py
+++ b/Python_version/grid.py
@@ -4,7 +4,6 @@ Definitions of the grid.
 '''
 
 import numpy as np
-import matplotlib.pyplot as plt
 
 import functions
 import gll
@@ -59,6 +58,7 @@ class OneDimensionalGrid(object):
         my_ticks gives the abscissa of the borders
         TODO I should test : _the types of the parameters
                              _their sizes"""
+        import matplotlib.pyplot as plt
         plt.figure(fig)
         sub1=plt.subplot(211)
         plt.hold(True)

--- a/Python_version/specfem1d.py
+++ b/Python_version/specfem1d.py
@@ -16,7 +16,6 @@ Main script for 1D spectral elements.
 """
 
 import numpy as np
-import matplotlib.pyplot as plt
 
 from config import Parameter
 from config import Source
@@ -46,6 +45,7 @@ u=np.zeros(param.nGlob,dtype='d')
 vel,acc=np.zeros_like(u),np.zeros_like(u)
 
 if param.plot:
+    import matplotlib.pyplot as plt
     plt.ion()
     fig = plt.figure()
     plt.hold(False)


### PR DESCRIPTION
Allow disabling plotting such that matplotlib is not imported at all. This is for the CI.